### PR TITLE
Treat cancelled tasks the same as checked tasks.

### DIFF
--- a/src/svelte/CheckCircle.svelte
+++ b/src/svelte/CheckCircle.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div class="checkbox">
-  <div class={checked == 'x' ? 'checked' : (checked == '/' ? 'inprog' : '')} />
+  <div class={(checked == 'x' || checked =='-') ? 'checked' : (checked == '/' ? 'inprog' : '')} />
 </div>
 
 <style>

--- a/src/utils/groups.ts
+++ b/src/utils/groups.ts
@@ -84,7 +84,7 @@ export const groupTodos = (
     }
 
   if (filterFullyComplete) {
-    const filtered = nonEmptyGroups.filter(group => !group.todos.every(todo => todo.checked === 'x'))
+    const filtered = nonEmptyGroups.filter(group => !group.todos.every(todo => todo.checked === 'x' || todo.checked === '-'))
     return [filtered, nonEmptyGroups.length - filtered.length]
   }
 

--- a/src/utils/tasks.ts
+++ b/src/utils/tasks.ts
@@ -106,10 +106,10 @@ export const parseTodos = async (
   for (const fileInfo of filesWithCache) {
     let todos = findAllTodosInFile(fileInfo)
     if (!showChecked) {
-      todos = todos.filter(todo => todo.checked != 'x')
+      todos = todos.filter(todo => todo.checked != 'x' && todo.checked != '-')
     }
     if (!showOther) {
-      todos = todos.filter(todo => todo.checked == ' ' || todo.checked == 'x')
+      todos = todos.filter(todo => todo.checked == ' ' || todo.checked == 'x' || todo.checked == '-')
     }
     todosForUpdatedFiles.set(fileInfo.file, todos)
   }


### PR DESCRIPTION
Thanks for adding the support for partially complete tasks. That's very useful for me and saves me a job! I made it so that cancelled tasks are treated the same as checked tasks because, personally, I don't want to see cancelled tasks on my todo list. I hope it's useful to you.